### PR TITLE
Upgrade bundled Debezium MySQL connector to 3.5.1.Final

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "mysql.cdc.driver"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Ballerina"]
 keywords = ["CDC", "Debezium", "MySQL", "Area/Database", "Type/Driver", "Vendor/Red Hat"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver"
@@ -15,32 +15,32 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "mysql.cdc.driver-native"
-version = "1.0.2"
-path = "../native/build/libs/mysql.cdc.driver-native-1.0.2.jar"
+version = "1.0.3"
+path = "../native/build/libs/mysql.cdc.driver-native-1.0.3-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-connector-mysql"
-version = "3.0.8.Final"
-path = "./lib/debezium-connector-mysql-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-connector-mysql-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-connector-binlog"
-version = "3.0.8.Final"
-path = "./lib/debezium-connector-binlog-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-connector-binlog-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-ddl-parser"
-version = "3.0.8.Final"
-path = "./lib/debezium-ddl-parser-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-ddl-parser-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "mysql-binlog-connector-java"
-version = "0.40.2"
-path = "./lib/mysql-binlog-connector-java-0.40.2.jar"
+version = "0.40.6"
+path = "./lib/mysql-binlog-connector-java-0.40.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.antlr"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "mysql.cdc.driver"
-version = "1.0.3"
+version = "1.1.0"
 authors = ["Ballerina"]
 keywords = ["CDC", "Debezium", "MySQL", "Area/Database", "Type/Driver", "Vendor/Red Hat"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "mysql.cdc.driver-native"
-version = "1.0.3"
-path = "../native/build/libs/mysql.cdc.driver-native-1.0.3.jar"
+version = "1.1.0"
+path = "../native/build/libs/mysql.cdc.driver-native-1.1.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -16,7 +16,7 @@ graalvmCompatible = true
 groupId = "io.ballerina.lib"
 artifactId = "mysql.cdc.driver-native"
 version = "1.0.3"
-path = "../native/build/libs/mysql.cdc.driver-native-1.0.3-SNAPSHOT.jar"
+path = "../native/build/libs/mysql.cdc.driver-native-1.0.3.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["CDC", "Debezium", "MySQL", "Area/Database", "Type/Driver", "Vendor/
 repository = "https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.12.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["CDC", "Debezium", "MySQL", "Area/Database", "Type/Driver", "Vendor/
 repository = "https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.13.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerinax"
 name = "mysql.cdc.driver"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerinax", name = "mysql.driver"}
 ]
@@ -21,7 +21,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql.driver"
-version = "1.8.0"
+version = "1.8.1"
 modules = [
 	{org = "ballerinax", packageName = "mysql.driver", moduleName = "mysql.driver"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerinax"
 name = "mysql.cdc.driver"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
 	{org = "ballerinax", name = "mysql.driver"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerinax"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerinax"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["CDC", "Debezium", "MySQL", "Area/Database", "Type/Driver", "Vendor/
 repository = "https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.12.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["CDC", "Debezium", "MySQL", "Area/Database", "Type/Driver", "Vendor/
 repository = "https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.13.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Upgrade the bundled Debezium MySQL connector to 3.5.1.Final.
+
+## [1.0.0]
+
+### Added
+- Introduce initial CDC specific drivers for MySQL
+
+### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
-ballerinaLangVersion=2201.13.0
+ballerinaLangVersion=2201.12.0
 
 debeziumVersion=3.5.1.Final
 debeziumMySQLBinLogVersion=0.40.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.13.0
 
 debeziumVersion=3.5.1.Final
 debeziumMySQLBinLogVersion=0.40.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.0.3-SNAPSHOT
+version=1.1.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18
@@ -11,6 +11,6 @@ ballerinaGradlePluginVersion=2.3.0
 
 ballerinaLangVersion=2201.12.0
 
-debeziumVersion=3.0.8.Final
-debeziumMySQLBinLogVersion=0.40.2
+debeziumVersion=3.5.1.Final
+debeziumMySQLBinLogVersion=0.40.6
 antlrVersion=4.10.1


### PR DESCRIPTION
## Summary
- Upgrades the bundled `debezium-connector-mysql`/`debezium-connector-binlog`/`debezium-ddl-parser` from 3.0.8.Final to 3.5.1.Final.
- Bumps `mysql-binlog-connector-java` from 0.40.2 to 0.40.6, the version required by Debezium 3.5.1's MySQL connector.
- Bumps package version 1.0.2 → 1.1.0.

## Test plan
- [x] Rebuilt the driver locally against Debezium 3.5.1.Final.
- [x] Verified against `module-ballerinax-mysql`'s full `cdc` group test suite — all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Upgraded the bundled Debezium MySQL connector components to `3.5.1.Final` and updated the MySQL binlog connector to `0.40.6`.
- Bumped the `mysql.cdc.driver` package version from `1.0.2` to `1.1.0` (including related dependency metadata updates).
- Refreshed Ballerina distribution/versioning and TOML/Gradle configuration to align with the updated build outputs.
- Updated `changelog.md` with the Debezium upgrade and added a new `1.0.0` section for MySQL CDC driver functionality.
- Rebuilt the driver locally and confirmed the `module-ballerinax-mysql` CDC group test suite passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->